### PR TITLE
Remove node/ from includes

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -1,8 +1,8 @@
 #define BUILDING_NODE_EXTENSION
 
-#include <node/v8.h>
-#include <node/node.h>
-#include <node/node_object_wrap.h>
+#include <v8.h>
+#include <node.h>
+#include <node_object_wrap.h>
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/query.cpp
+++ b/src/query.cpp
@@ -1,7 +1,7 @@
-#include <node/v8.h>
-#include <node/node.h>
-#include <node/node_object_wrap.h>
-#include <node/node_buffer.h>
+#include <v8.h>
+#include <node.h>
+#include <node_object_wrap.h>
+#include <node_buffer.h>
 
 #include <string.h>
 #include <stdlib.h>


### PR DESCRIPTION
Hi,
I've removed "node/" from includes: noge-gyp finds automatically directories. This is required for distribution packaging.